### PR TITLE
Add LLM column detection skeleton

### DIFF
--- a/src/llm/detector.py
+++ b/src/llm/detector.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from typing import Optional
+
+import openai
+import pandas as pd
+
+from . import prompts, schema
+
+
+_DEBIT_RE = re.compile(r"^(дебет|дт|debit)$", re.IGNORECASE)
+_CREDIT_RE = re.compile(r"^(кредит|кт|credit)$", re.IGNORECASE)
+
+
+def _heuristic_detection(df: pd.DataFrame) -> schema.Detection:
+    debit_idx: Optional[int] = None
+    credit_idx: Optional[int] = None
+    for i, col in enumerate(map(str, df.columns)):
+        norm = col.strip().lower()
+        if debit_idx is None and _DEBIT_RE.match(norm):
+            debit_idx = i
+        if credit_idx is None and _CREDIT_RE.match(norm):
+            credit_idx = i
+    if debit_idx is None or credit_idx is None:
+        raise ValueError("Could not heuristically determine debit/credit columns")
+    return schema.Detection(
+        debit_column=debit_idx,
+        credit_column=credit_idx,
+        header_row=0,
+        start_row=1,
+        end_row=len(df),
+        group_keys=[],
+    )
+
+
+def detect_columns(df: pd.DataFrame, api_key: str, model: str = "gpt-4o-mini") -> schema.Detection:
+    """Detect debit and credit columns using OpenAI with heuristic fallback."""
+    if not api_key:
+        return _heuristic_detection(df)
+
+    openai.api_key = api_key
+    prompt = prompts.build_prompt(df)
+    messages = [
+        {"role": "user", "content": prompt},
+    ]
+
+    for attempt in range(3):
+        try:
+            resp = openai.ChatCompletion.create(model=model, messages=messages)
+            content = resp.choices[0].message["content"]
+            data = json.loads(content)
+            return schema.Detection(**data)
+        except Exception:
+            time.sleep(2 ** attempt)
+
+    # fallback
+    return _heuristic_detection(df)

--- a/src/llm/prompts.py
+++ b/src/llm/prompts.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from textwrap import dedent
+import pandas as pd
+
+
+FEW_SHOT = dedent(
+    """
+    You are given CSV data from an accounting workbook. Identify which columns
+    hold debit and credit amounts.
+
+    Example CSV:
+    date,debit,credit
+    2024-01-01,100,0
+    2024-01-02,0,50
+
+    Example answer:
+    {"debit_column":1,"credit_column":2,"header_row":0,"start_row":1,"end_row":3,"group_keys":["date"]}
+    """
+)
+
+
+def build_prompt(df: pd.DataFrame) -> str:
+    """Create a prompt showing head and tail rows as CSV."""
+    head = df.head(7)
+    tail = df.tail(7)
+    sample = pd.concat([head, tail]).to_csv(index=False)
+
+    return dedent(
+        f"{FEW_SHOT}\nAnalyse the following table and respond with JSON in the same schema.\nCSV:\n{sample}"
+    )

--- a/src/llm/schema.py
+++ b/src/llm/schema.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import List
+from pydantic import BaseModel
+
+class Detection(BaseModel):
+    """Model returned by the LLM column detector."""
+
+    debit_column: int
+    credit_column: int
+    header_row: int
+    start_row: int
+    end_row: int
+    group_keys: List[str]

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from src.llm.detector import detect_columns
+
+
+def test_detect_columns_heuristic():
+    df = pd.DataFrame({
+        'Дебет': [1, 2],
+        'Кредит': [1, 2],
+        'Описание': ['a', 'b'],
+    })
+    detection = detect_columns(df, api_key="")
+    assert detection.debit_column == 0
+    assert detection.credit_column == 1
+    assert detection.start_row == 1
+    assert detection.end_row == len(df)


### PR DESCRIPTION
## Summary
- add `schema.Detection` pydantic model
- add prompt builder with a few-shot example
- add column detection function using OpenAI with regex fallback
- cover heuristics with unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687a69232830832fbead3638fd0df107