### PR TITLE
Implement mismatch highlighting

### DIFF
--- a/src/core/highlight.py
+++ b/src/core/highlight.py
@@ -1,10 +1,58 @@
-"""Placeholder for highlighting logic."""
+"""Utility functions for computing mismatch highlights."""
 
 from __future__ import annotations
 
-from typing import Set, Tuple
+from typing import Iterable, List, Set, Tuple
 
 import pandas as pd
+
+from .reconcile import Match, Partial, Unmatched
+from src.llm.schema import Detection
+
+
+def cells_to_highlight(
+    matches: Iterable[Match],
+    partials: Iterable[Partial],
+    unmatched: Iterable[Unmatched],
+    detection: Detection,
+    side: str,
+) -> Set[Tuple[int, int]]:
+    """Return set of cell coordinates to highlight for one reconciliation side.
+
+    Parameters
+    ----------
+    matches, partials, unmatched:
+        Results returned by :func:`reconcile`.
+    detection:
+        Column detection metadata for the respective table.
+    side:
+        Either ``"left"`` or ``"right"`` indicating which table to process.
+    """
+
+    debit_col = detection.debit_column
+    credit_col = detection.credit_column
+    cells: Set[Tuple[int, int]] = set()
+
+    def _add_row(row: int) -> None:
+        cells.add((row, debit_col))
+        cells.add((row, credit_col))
+
+    for u in unmatched:
+        if u.side == side:
+            _add_row(u.row)
+
+    for p in partials:
+        rows = p.left_rows if side == "left" else p.right_rows
+        for r in rows:
+            _add_row(r)
+
+    for m in matches:
+        if m.diff != 0:
+            rows = m.left_rows if side == "left" else m.right_rows
+            for r in rows:
+                _add_row(r)
+
+    return cells
 
 
 def highlight_mismatches(df: pd.DataFrame, mismatch_rows: Set[Tuple[int, int]]) -> pd.DataFrame:

--- a/tests/test_highlight.py
+++ b/tests/test_highlight.py
@@ -1,0 +1,43 @@
+import pandas as pd
+from src.core.reconcile import reconcile
+from src.core.highlight import cells_to_highlight
+from src.llm.schema import Detection
+
+
+def _det(df: pd.DataFrame) -> Detection:
+    return Detection(
+        debit_column=0,
+        credit_column=1,
+        header_row=0,
+        start_row=1,
+        end_row=len(df),
+        group_keys=[],
+    )
+
+
+def test_cells_to_highlight_none():
+    left = pd.DataFrame({"debit": [100], "credit": [0]})
+    right = pd.DataFrame({"debit": [100], "credit": [0]})
+    det = _det(left)
+    matches, partials, unmatched = reconcile(left, right, det, det)
+    assert cells_to_highlight(matches, partials, unmatched, det, "left") == set()
+    assert cells_to_highlight(matches, partials, unmatched, det, "right") == set()
+
+
+def test_cells_to_highlight_partial_unmatched():
+    left = pd.DataFrame({"debit": [50], "credit": [0]})
+    right = pd.DataFrame({"debit": [40], "credit": [0]})
+    det = _det(left)
+    matches, partials, unmatched = reconcile(left, right, det, det)
+    expected = {(0, 0), (0, 1)}
+    assert cells_to_highlight(matches, partials, unmatched, det, "left") == expected
+    assert cells_to_highlight(matches, partials, unmatched, det, "right") == expected
+
+
+def test_cells_to_highlight_extra_right_row():
+    left = pd.DataFrame({"debit": [20], "credit": [0]})
+    right = pd.DataFrame({"debit": [20, 30], "credit": [0, 0]})
+    det = _det(left)
+    matches, partials, unmatched = reconcile(left, right, det, det)
+    assert cells_to_highlight(matches, partials, unmatched, det, "left") == set()
+    assert cells_to_highlight(matches, partials, unmatched, det, "right") == {(1, 0), (1, 1)}


### PR DESCRIPTION
## Summary
- implement `cells_to_highlight` for selecting mismatching cells
- cover highlighting logic with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6e55a198832fb8fbf5f8cd2d3421