### PR TITLE
Fix Streamlit import path

### DIFF
--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -5,6 +5,12 @@ from io import BytesIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Tuple
+import sys
+
+# Ensure imports work when running this file directly with Streamlit or Python.
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
 
 import pandas as pd
 import streamlit as st


### PR DESCRIPTION
## Summary
- ensure project root is added to `sys.path` when running `app.py` directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a80928630832faf52fda25f7f721b