### PR TITLE
Add early debit-credit total check

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ make run  # or `streamlit run src/ui/app.py`
 ```
 
 Upload the two workbooks, provide the API key if desired and press
-**Reconcile**. The app will offer downloads for the coloured Excel files and a
-text report.
+**Reconcile**. The app first compares the total debit of the left workbook with
+the total credit of the right. If they match a short confirmation is returned,
+otherwise a detailed reconciliation is performed. In both cases the app offers
+downloads for the coloured Excel files and a text report.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- add an early debit vs credit totals check to `_run_reconcile`
- update README with explanation of the new check

## Testing
- `pip install openai pydantic`
- `make test`
- `pip install flake8`
- `make lint` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_687e34608164832fae2f1e17cfb45f9a