### PR TITLE
Add cross total check both directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ make run  # or `streamlit run src/ui/app.py`
 ```
 
 Upload the two workbooks, provide the API key if desired and press
-**Reconcile**. The app first compares the total debit of the left workbook with
-the total credit of the right. If they match a short confirmation is returned,
-otherwise a detailed reconciliation is performed. In both cases the app offers
-downloads for the coloured Excel files and a text report.
+**Reconcile**. The app first compares totals in both directions: debit from the
+left versus credit from the right and credit from the left versus debit from the
+right. If both pairs of totals match a short confirmation is returned, otherwise
+a detailed reconciliation is performed. In both cases the app offers downloads
+for the coloured Excel files and a text report.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- compute debit/credit totals for both workbooks
- short‑circuit reconciliation when both cross totals match
- clarify README about the new behaviour

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6880ba774aec832f9d2b7e55c5a959f6